### PR TITLE
add @flask_endpoint to log and debug endpoints

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+PROGRAM_NAME="flask-truss"
+PROGRAM_STATIC_NAME="flask-truss-static"
+INSTALL_PATH="/usr/local/bin/"
+STATIC_FILES_INSTALL_PATH="/srv/www"
+DEV_DEPS="python python-dev python-virtualenv python3 python3-dev git"
+SYSTEM_DEPS="libpq-dev libffi-dev"
+
+SRC_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+CONTAINER_NAME='flask_truss.lxc'
+
+lxc_config="/var/lib/lxc/$CONTAINER_NAME/config"
+lxc_rootfs="/var/lib/lxc/$CONTAINER_NAME/rootfs/"
+
+Lxc_create() {
+    name=$1
+    if [[ -z $name ]]; then
+    cat <<EOF
+Lxc_create container_name
+default is to use ubuntu template
+EOF
+    else
+        container_template=ubuntu
+        auth_keys=".ssh/authorized_keys"
+        sudo -E lxc-create -t $container_template -n $name -- -u $SUDO_USER -S $HOME/$auth_keys
+        sudo -E lxc-start -d -n $name
+    fi
+}
+
+install_deps() {
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+        sudo apt-get update
+        sudo apt-get install -y lxc liblxc1 python3-lxc
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        echo 'sorry lxc does not work on OSX, use a vagrant VM'
+        exit 1
+    fi
+}
+
+bootstrap() {
+    Lxc_create $CONTAINER_NAME
+    sudo chroot $lxc_rootfs sudo apt-get update
+    sudo chroot $lxc_rootfs sudo apt-get install -y $DEV_DEPS
+    sudo chroot $lxc_rootfs sudo apt-get install -y $SYSTEM_DEPS
+
+    repo_mount="lxc.mount.entry = $SRC_DIR home/$SUDO_USER/$PROGRAM_NAME none bind,create=dir 0 0"
+    if ! grep -q "$repo_mount" "$lxc_config"; then
+        echo "$repo_mount" | sudo tee -a $lxc_config
+    fi
+    sudo lxc-stop -n "$CONTAINER_NAME"
+    sudo lxc-start -d -n "$CONTAINER_NAME"
+}
+
+clean() {
+    # Clean up packaging artifacts
+    rm -rf $SRC_DIR/build
+    rm -rf $SRC_DIR/dist
+    rm -rf $SRC_DIR/*.egg-info
+    rm -rf $SRC_DIR/*.deb
+    rm -rf $INSTALL_PATH/$PROGRAM_NAME
+    rm -rf $STATIC_FILES_INSTALL_PATH/$PROGRAM_STATIC_NAME
+    find . -name '*.pyc' -delete
+}
+
+usage() {
+    msgs=(
+        'build.sh option [arg]'
+        '-b | --bootstrap - create minimal dev lxc container'
+    )
+
+    for msg in "${msgs[@]}"; do
+        echo $msg
+    done
+
+    exit 1
+}
+
+main() {
+    options=$@
+    args=($options)
+    i=0
+
+    for arg in $options; do
+        i=$(( $i + 1 ))
+
+        case $arg in
+            -b|--bootstrap|bootstrap)
+                bootstrap
+                break
+                ;;
+            *)
+                usage
+                break
+                ;;
+        esac
+    done
+}
+
+main $@

--- a/flask_truss/blueprints/_blueprint/__init__.py
+++ b/flask_truss/blueprints/_blueprint/__init__.py
@@ -1,15 +1,14 @@
 from flask import Blueprint, render_template, current_app, request
 
 from flask_truss.async._task import _task
-from flask_truss.lib.logger import log_flask_request
+from flask_truss.lib.logger import flask_endpoint
 
 
 _blueprint = Blueprint('_blueprint', __name__, template_folder='templates')
 
-
 @_blueprint.route('/')
+@flask_endpoint(log_percent=0.10)
 def render_blueprint():
-    log_flask_request(current_app, request)
     # Call _task.delay() or _task.apply_async(...) if you've set up a broker.
     _task()
     return render_template('_blueprint.j2', content=None)

--- a/flask_truss/conf/app.py
+++ b/flask_truss/conf/app.py
@@ -14,8 +14,13 @@ class Config(object):
         self.DEBUG = True
         self.TESTING = False
         self.THREADED = False
-        self.LOGGER_NAME = 'stderr'
-        self.LOGGER_SYSLOGTAG = 'FLASK_TRUSS'
+
+        # logging and performance
+        self.MODULE_NAME = __name__.split('.', 1)[0]
+        self.LOGGER_NAME = 'debug'
+        self.LOGGER_SYSLOGTAG = self.MODULE_NAME.upper()
+        self.STATSD_HOST = 'localhost'
+        self.STATSD_PORT = 8125
 
         # SQLAlchemy settings
         self.SQLALCHEMY_RECORD_QUERIES = False

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'pytz',
         'randomize',
         'SQLAlchemy',
+        'statsd',
         'Werkzeug',
     ],
     tests_require=['nose'],


### PR DESCRIPTION
this decorator lets you debug a flask endpoint using statsd
and logging.

the statsd side of the endpoint decorator gives you
two important factors, number of times the endpoint was hit and
the time it took to exec the endpoint. statsd uses udp, so there's
no infrastructure dependencies required.

the logging side constructs a log message using the flask request
and then writes it to info.logger

you can tune what % of requests are logged through the log_percent var,
and the is_active param lets you disable the decorator regardless of the
log_percent

@EricWorkman 